### PR TITLE
Fixes a bug where baseUrl is not set in some scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for 204 no content responses
 
+### Changed
+
+- Fixed a bug where BaseUrl would not be set in some scenarios
+
 ## [1.0.0-preview.2] - 2022-03-18
 
 ### Changed

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
@@ -44,6 +44,26 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             Assert.IsAssignableFrom(backingStore.GetType(), BackingStoreFactorySingleton.Instance);
         }
 
+
+        [Fact]
+        public void GetRequestMessageFromRequestInformationWithBaseUrlTemplate()
+        {
+            // Arrange
+            requestAdapter.BaseUrl = "http://localhost";
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "{+baseurl}/me"
+            };
+
+            // Act
+            var requestMessage = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
+
+            // Assert
+            Assert.NotNull(requestMessage.RequestUri);
+            Assert.Contains("http://localhost/me", requestMessage.RequestUri.OriginalString);
+        }
+
         [Theory]
         [InlineData("select", new[] { "id", "displayName" }, "select=id,displayName")]
         [InlineData("count", true, "count=true")]

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         }
         private void SetBaseUrlForRequestInformation(RequestInformation requestInfo)
         {
-            requestInfo.PathParameters.Add("baseurl", BaseUrl);
+            requestInfo.PathParameters.TryAdd("baseurl", BaseUrl);
         }
         /// <summary>
         /// Creates a <see cref="HttpRequestMessage"/> instance from a <see cref="RequestInformation"/> instance.
@@ -312,6 +312,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// <returns>A <see cref="HttpRequestMessage"/> instance</returns>
         public HttpRequestMessage GetRequestMessageFromRequestInformation(RequestInformation requestInfo)
         {
+            SetBaseUrlForRequestInformation(requestInfo);// this method can also be called from a different context so ensure the baseUrl is added.
             var message = new HttpRequestMessage
             {
                 Method = new HttpMethod(requestInfo.HttpMethod.ToString().ToUpperInvariant()),

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -23,6 +23,7 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
         - Added support for 204 no content responses
+        - Fixed a bug where BaseUrl would not be set in some scenarios
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR fixes a bug where there `BaseUrl` is not set in some code paths when `GetRequestMessageFromRequestInformation` is called.

The PR targets #4 so that the fix may be released together. 