### PR TITLE
Changes target runtime to netstandard2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.6] - 2022-04-12
+
+### Changed
+
+- Breaking: Changes target runtime to netstandard2.0
+
 ## [1.0.0-preview.5] - 2022-04-07
 
 ### Added

--- a/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Extensions/HttpRequestMessageExtensions.cs
@@ -2,11 +2,12 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
 {
@@ -45,12 +46,12 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
             var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
 
             // Copy request headers.
-            foreach(var (key, value) in originalRequest.Headers)
-                newRequest.Headers.TryAddWithoutValidation(key, value);
+            foreach(var header in originalRequest.Headers)
+                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
 
             // Copy request properties.
-            foreach(var (key, value) in originalRequest.Properties)
-                newRequest.Properties.TryAdd(key, value);
+            foreach(var property in originalRequest.Properties)
+                newRequest.Properties.TryAdd(property.Key, property.Value);
 
             // Set Content if previous request had one.
             if(originalRequest.Content != null)
@@ -64,9 +65,9 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
                 newRequest.Content = new StreamContent(contentStream);
 
                 // Copy content headers.
-                foreach(var (key, value) in originalRequest.Content.Headers)
+                foreach(var header in originalRequest.Content.Headers)
                 {
-                    newRequest.Content?.Headers.TryAddWithoutValidation(key, value);
+                    newRequest.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }
             }
 
@@ -82,7 +83,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
         {
             HttpContent requestContent = httpRequestMessage.Content;
 
-            if((httpRequestMessage.Method == HttpMethod.Put || httpRequestMessage.Method == HttpMethod.Post || httpRequestMessage.Method == HttpMethod.Patch)
+            if((httpRequestMessage.Method == HttpMethod.Put || httpRequestMessage.Method == HttpMethod.Post || httpRequestMessage.Method.Method.Equals("PATCH", StringComparison.OrdinalIgnoreCase))
                && requestContent != null && (requestContent.Headers.ContentLength == null || (int)requestContent.Headers.ContentLength == -1))
             {
                 return false;

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -14,6 +14,7 @@ using Microsoft.Kiota.Abstractions.Store;
 using Microsoft.Kiota.Abstractions.Authentication;
 using System.Threading;
 using System.Net;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary
 {
@@ -331,9 +332,9 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(requestInfo.Content != null)
                 message.Content = new StreamContent(requestInfo.Content);
             if(requestInfo.Headers?.Any() ?? false)
-                foreach(var (key,value) in requestInfo.Headers)
-                    if(!message.Headers.TryAddWithoutValidation(key, value) && message.Content != null)
-                        message.Content.Headers.TryAddWithoutValidation(key, value);// Try to add the headers we couldn't add to the HttpRequestMessage before to the HttpContent
+                foreach(var header in requestInfo.Headers)
+                    if(!message.Headers.TryAddWithoutValidation(header.Key, header.Value) && message.Content != null)
+                        message.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);// Try to add the headers we couldn't add to the HttpRequestMessage before to the HttpContent
 
             return message;
         }

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 }
             }
             if(finalHandler != null)
-                handlers[^1].InnerHandler = finalHandler;
+                handlers[handlers.Length-1].InnerHandler = finalHandler;
             return handlers.First();
         }
         /// <summary>

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Http Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-http-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionSuffix>preview.6</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -22,7 +22,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-      - Added supports for decoding parameter names.
+        - Breaking: Changes target runtime to netstandard2.0
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.4" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.5" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>

--- a/src/Middleware/ChaosHandler.cs
+++ b/src/Middleware/ChaosHandler.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             });
             var throttleResponse = new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.TooManyRequests,
+                StatusCode = (HttpStatusCode)429,
                 Content = new StringContent(contentString, Encoding.UTF8, Json)
             };
             throttleResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             {
                 HttpStatusCode.ServiceUnavailable => true,
                 HttpStatusCode.GatewayTimeout => true,
-                HttpStatusCode.TooManyRequests => true,
+                (HttpStatusCode)429 => true,
                 _ => false
             };
         }


### PR DESCRIPTION
This is part of https://github.com/microsoft/kiota-abstractions-dotnet/issues/12

Depends on https://github.com/microsoft/kiota-abstractions-dotnet/pull/14

Changes include: -

- use tryAdd from abstractions
- undo use of deconstructors
- use cast instances of HttpStatusCode and HttpMethod.Patch
- undo use of indexers