### PR TITLE
Update RetryHandler.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.12] - 2022-12-01
+
+### Changed
+
+- Fixes RetryHandler to return the real wait time
+
 ## [1.0.0-preview.11] - 2022-10-17
 
 ### Changed
 
-- Changes the ResponeHandler parameter in IRequestAdapter to be a RequestOption
+- Changes the ResponseHandler parameter in IRequestAdapter to be a RequestOption
 
 ## [1.0.0-preview.10] - 2022-09-19
 

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.11</VersionSuffix>
+    <VersionSuffix>preview.12</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -22,7 +22,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Changes the ResponeHandler parameter in IRequestAdapter to be a RequestOption
+        - Fixes RetryHandler to return the real wait time
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             }
 
             TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MaxDelay));
+            delayInSeconds=delayTimeSpan.TotalSeconds;
             return Task.Delay(delayTimeSpan, cancellationToken);
         }
 


### PR DESCRIPTION
Delay should return the real wait time

This is from an issue in old version Microsoft Graph Core SDK, https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/525, I used to merge it into graph SDK, but in new version, retry handler is moved to kiota project, so merge this issue here.