### PR TITLE
multi-value headers support release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.13] - 2022-12-14
+
+### Changed
+
+- Added multi-value headers support.
+
 ## [1.0.0-preview.12] - 2022-12-01
 
 ### Changed

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.12</VersionSuffix>
+    <VersionSuffix>preview.13</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -22,7 +22,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Fixes RetryHandler to return the real wait time
+        - Added multi-value headers support.
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR creates a new release of the library after https://github.com/microsoft/kiota-http-dotnet/pull/61

As the Headers property type has now been updated, the library may throw an error as it currently expects the Headers type to be a dictionary if the older version of Abstractions is used.

This ensures that a version is available with the explicit contraint.  
