### PR TITLE
Release candidate 1

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -75,7 +75,7 @@ stages:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Http.HttpClientLibrary.sln'
-          arguments: '--configuration $(BuildConfiguration) --no-build'
+          arguments: '--configuration $(BuildConfiguration) --no-build -f net6.0'
 
       # CredScan
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
@@ -260,6 +260,12 @@ stages:
             pool:
               vmImage: ubuntu-latest
             steps:
+            # Install the nuget tool.
+            - task: NuGetToolInstaller@0
+              displayName: 'Use NuGet >=5.2.0'
+              inputs:
+                versionSpec: '>=5.2.0'
+                checkLatest: true
             - task: DownloadPipelineArtifact@2
               displayName: Download nupkg from artifacts
               inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -62,6 +62,15 @@ stages:
           pwsh: true
         enabled: true
 
+      - task: PowerShell@2
+        displayName: 'Enable signing'
+        inputs:
+          targetType: filePath
+          filePath: 'scripts\EnableSigning.ps1'
+          arguments: '-projectPath "$(Build.SourcesDirectory)/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj"'
+          pwsh: true
+        enabled: true
+
       # Build the Product project
       - task: DotNetCoreCLI@2
         displayName: 'Build Microsoft.Kiota.Http.HttpClientLibrary'

--- a/.github/workflows/build-and_test.yml
+++ b/.github/workflows/build-and_test.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
       - name: Build
-        run: dotnet build ${{ env.solutionName }} --no-restore -c Release /p:UseSharedCompilation=false
+        run: dotnet build ${{ env.solutionName }} --no-restore -c Debug /p:UseSharedCompilation=false
       - name: Test
-        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
+        run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Debug /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.0-rc.1] - 2022-12-15
+
+### Changed
+
+- Release candidate 1
+
 ### Changed
 
 ## [1.0.0-preview.13] - 2022-12-14

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -101,8 +101,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             Assert.NotNull(clonedRequest);
             Assert.Equal(originalRequest.Method, clonedRequest.Method);
             Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.NotEmpty(clonedRequest.Properties);
             Assert.Equal(redirectHandlerOption, clonedRequest.Properties.First().Value);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
         }
 

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
             Assert.NotNull(clonedRequest);
             Assert.Equal(originalRequest.Method, clonedRequest.Method);
             Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
-            Assert.NotEmpty(clonedRequest.Options);
-            Assert.Equal(redirectHandlerOption, clonedRequest.Options.First().Value);
+            Assert.NotEmpty(clonedRequest.Properties);
+            Assert.Equal(redirectHandlerOption, clonedRequest.Properties.First().Value);
             Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
         }
 

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\src\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>True</DelaySign>
+    <LangVersion>latest</LangVersion>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -5,6 +5,9 @@
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\src\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/ChaosHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/ChaosHandlerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             }
 
             // Assert
-            Assert.True(responses.ContainsKey(HttpStatusCode.TooManyRequests));
+            Assert.True(responses.ContainsKey((HttpStatusCode)429));
             Assert.True(responses.ContainsKey(HttpStatusCode.ServiceUnavailable));
             Assert.True(responses.ContainsKey(HttpStatusCode.GatewayTimeout));
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             }
 
             // Assert
-            Assert.True(responses.ContainsKey(HttpStatusCode.TooManyRequests));
+            Assert.True(responses.ContainsKey((HttpStatusCode)429));
             Assert.True(responses.ContainsKey(HttpStatusCode.InternalServerError));
             Assert.True(responses.ContainsKey(HttpStatusCode.BadGateway));
             Assert.True(responses.ContainsKey(HttpStatusCode.ServiceUnavailable));
@@ -109,25 +109,22 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 InnerHandler = new FakeSuccessHandler()
             };
 
-            var invoker = new HttpMessageInvoker(handler);
-
-
             // Act
             var request1 = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://example.org/success")
             };
-            var response1 = await invoker.SendAsync(request1, new CancellationToken());
+            var response1 = await new HttpMessageInvoker(handler).SendAsync(request1, new CancellationToken());
 
             var request2 = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://example.org/fail")
             };
-            var response2 = await invoker.SendAsync(request2, new CancellationToken());
+            var response2 = await new HttpMessageInvoker(handler).SendAsync(request2, new CancellationToken());
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
-            Assert.Equal(HttpStatusCode.TooManyRequests, response2.StatusCode);
+            Assert.Equal((HttpStatusCode)429, response2.StatusCode);
         }
 
     }

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RedirectHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RedirectHandlerTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
+        [InlineData((HttpStatusCode)308)] // 308 not available in netstandard
         public async Task ShouldRedirectSameMethodAndContent(HttpStatusCode statusCode)
         {
             // Arrange
@@ -130,7 +130,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
+        [InlineData((HttpStatusCode)308)] // 308
         public async Task RedirectWithDifferentHostShouldRemoveAuthHeader(HttpStatusCode statusCode)
         {
             // Arrange
@@ -151,7 +151,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
+        [InlineData((HttpStatusCode)308)] // 308
         public async Task RedirectWithDifferentSchemeThrowsInvalidOperationExceptionIfAllowRedirectOnSchemeChangeIsDisabled(HttpStatusCode statusCode)
         {
             // Arrange
@@ -172,7 +172,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-        [InlineData(HttpStatusCode.PermanentRedirect)] // 308
+        [InlineData((HttpStatusCode)308)] // 308
         public async Task RedirectWithDifferentSchemeShouldRemoveAuthHeaderIfAllowRedirectOnSchemeChangeIsEnabled(HttpStatusCode statusCode)
         {
             // Arrange

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Mocks/MockCompressedContent.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Mocks/MockCompressedContent.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Mocks
         public MockCompressedContent(HttpContent httpContent)
         {
             _originalContent = httpContent;
-            foreach(var (key, value) in _originalContent.Headers)
-                Headers.TryAddWithoutValidation(key, value);
+            foreach(var header in _originalContent.Headers)
+                Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             Stream compressedStream = new GZipStream(stream, CompressionMode.Compress, true);
             await _originalContent.CopyToAsync(compressedStream);
-            await compressedStream.DisposeAsync();
+            compressedStream.Dispose();
         }
 
         protected override bool TryComputeLength(out long length)

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         }
         private bool shouldReturnNull(HttpResponseMessage response)
         {
-            return response.StatusCode == HttpStatusCode.NoContent;
+            return response.StatusCode == HttpStatusCode.NoContent || response.Content == null;
         }
         /// <summary>
         /// The attribute name used to indicate whether an error code mapping was found.
@@ -372,7 +372,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         private async Task<IParseNode> GetRootParseNode(HttpResponseMessage response)
         {
             using var span = activitySource?.StartActivity(nameof(GetRootParseNode));
-            var responseContentType = response.Content.Headers?.ContentType?.MediaType?.ToLowerInvariant();
+            var responseContentType = response.Content?.Headers?.ContentType?.MediaType?.ToLowerInvariant();
             if(string.IsNullOrEmpty(responseContentType))
                 return null;
             using var contentStream = await response.Content.ReadAsStreamAsync();
@@ -511,15 +511,25 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(backingStoreFactory != null)
                 BackingStoreFactorySingleton.Instance = backingStoreFactory;
         }
+
         /// <summary>
         /// Dispose/cleanup the client
         /// </summary>
         public void Dispose()
         {
-            if(createdClient)
-                client?.Dispose();
+            Dispose(true);
             activitySource?.Dispose();
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose/cleanup the client
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            // Cleanup
+            if(createdClient)
+                client?.Dispose();
         }
     }
 }

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -518,8 +518,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         public void Dispose()
         {
             Dispose(true);
-            activitySource?.Dispose();
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -529,7 +527,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         {
             // Cleanup
             if(createdClient)
+            {
+                activitySource?.Dispose();
                 client?.Dispose();
+                GC.SuppressFinalize(this);
+            }
         }
     }
 }

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -518,6 +518,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -530,7 +531,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             {
                 activitySource?.Dispose();
                 client?.Dispose();
-                GC.SuppressFinalize(this);
             }
         }
     }

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.13</VersionSuffix>
+    <VersionSuffix>rc.1</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
@@ -22,16 +22,17 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Added multi-value headers support.
+        - Release candidate 1
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.19" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.1" />
   </ItemGroup>
@@ -42,6 +43,10 @@
 
   <ItemGroup>
     <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -16,4 +16,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM.
 
 [assembly: Guid("b0c91cbc-af85-4c64-b989-d320e6989b2a")]
+
+#if DEBUG
+[assembly: InternalsVisibleTo("Microsoft.Kiota.Http.HttpClientLibrary.Tests")]
+#else
 [assembly: InternalsVisibleTo("Microsoft.Kiota.Http.HttpClientLibrary.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#endif


### PR DESCRIPTION
This PR creates a release candidate release for the library

Changes include -
- Ensure the nuget push task uses version greater than 5.2.0 to ensure debug symbols are pushed
- Include readme in nuget package in accordance with https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/
- Adds `net462` target to the test project so that project is tested against NetFramework as well.
- Fixes potential NullReference exceptions discovered as `HttpResponseMessage.Content` can be null in versions of dotnet lower than .NET 5