### PR TITLE
Fix release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -30,9 +30,9 @@ stages:
       steps:
 
       - task: UseDotNet@2
-        displayName: 'Use .NET 6'
+        displayName: 'Use .NET 7'
         inputs:
-          version: 6.x
+          version: 7.x
 
       - task: PoliCheck@1
         displayName: 'Run PoliCheck "/src"'

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Updates release pipeline to use .NET as Azure Devops  fails due to using older compiler due to dependencies 
at https://github.com/microsoft/kiota-http-dotnet/blob/main/Kiota.Generated/KiotaGenerated.csproj

