### PR TITLE
Aligns the BaseUrl for making requests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -71,7 +71,7 @@ jobs:
           CoverletOutputFormat: 'opencover' # https://github.com/microsoft/vstest/issues/4014#issuecomment-1307913682
         shell: pwsh
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"microsoft_kiota-http-dotnet" /o:"microsoft" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="Microsoft.Kiota.Http.HttpClientLibrary.Tests/coverage.net6.0.opencover.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"microsoft_kiota-http-dotnet" /o:"microsoft" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="Microsoft.Kiota.Http.HttpClientLibrary.Tests/coverage.net7.0.opencover.xml"
           dotnet workload restore
           dotnet build
           dotnet test Microsoft.Kiota.Http.HttpClientLibrary.sln --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.0-rc.5] - 2023-01-23
+
+### Changed
+
+- Aligns the HttpClientRequestAdapter to use the BaseUrl from the RequestAdapter as the baseUrl for making requests. 
+
 ## [1.0.0-rc.4] - 2023-01-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Aligns the HttpClientRequestAdapter to use the BaseUrl from the RequestAdapter as the baseUrl for making requests. 
+- Aligns the HttpClientRequestAdapter with other langugages to use the BaseUrl from the RequestAdapter as the baseUrl for making requests. 
 
 ## [1.0.0-rc.4] - 2023-01-09
 

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         }
         private void SetBaseUrlForRequestInformation(RequestInformation requestInfo)
         {
-            IDictionaryExtensions.TryAdd(requestInfo.PathParameters, "baseurl", BaseUrl!);
+            IDictionaryExtensions.AddOrReplace(requestInfo.PathParameters, "baseurl", BaseUrl!);
         }
         /// <inheritdoc/>
         public async Task<T?> ConvertToNativeRequestAsync<T>(RequestInformation requestInfo, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.4</VersionSuffix>
+    <VersionSuffix>rc.5</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->


### PR DESCRIPTION
This PR aligns the HttpClientRequestAdapter with other languages to use the BaseUrl from the RequestAdapter as the baseUrl for making requests.

Reference
- https://github.com/microsoft/kiota-http-go/blob/6ec82d769c78e2a87d3bfa8a87c2cbcbecd5326a/nethttp_request_adapter.go#L206
- https://github.com/microsoft/kiota-java/blob/20a42d0a968ba7460c8cf42f261a4c9da5934d45/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java#L745