### PR TITLE
Use sliding version for System.Diagnostics.DiagnosticSource and System.Text.Json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.1] - 2023-03-10
+
+### Changed
+
+- Update minimum version of [`System.Diagnostics.DiagnosticSource`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) to `6.0.0`.
+- Update minimum version of [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json) to `6.0.0`.
+
 ## [1.0.0] - 2023-02-27
 
 ### Added

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -35,9 +35,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6.0,8.0)" />
+    <PackageReference Include="System.Text.Json" Version="[6.0,8.0)" />
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1670 and https://github.com/microsoft/kiota-serialization-json-dotnet/issues/69

Conflicting libraries for users on .NET 6 run into issues when forced to use the v7 of the library.

Depends on https://github.com/microsoft/kiota-abstractions-dotnet/pull/73

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1670