### PR TITLE
Default RequestAdapter BaseUrl to client BaseAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2023-06-09
+
+- Added propagating the HttpClientRequestAdapter's supplied HttpClient BaseAddress as the adapter's initial BaseUrl
+
 ### Added
 
 ## [1.0.2] - 2023-04-06

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             authProvider = authenticationProvider ?? throw new ArgumentNullException(nameof(authenticationProvider));
             createdClient = httpClient == null;
             client = httpClient ?? KiotaClientFactory.Create();
+            BaseUrl = client.BaseAddress.ToString();
             pNodeFactory = parseNodeFactory ?? ParseNodeFactoryRegistry.DefaultInstance;
             sWriterFactory = serializationWriterFactory ?? SerializationWriterFactoryRegistry.DefaultInstance;
             obsOptions = observabilityOptions ?? new ObservabilityOptions();
@@ -374,7 +375,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 apiEx.ResponseStatusCode = statusCodeAsInt;
                 apiEx.ResponseHeaders = responseHeadersDictionary;
             }
-                
+
             throw ex;
         }
         private static IResponseHandler? GetResponseHandler(RequestInformation requestInfo)

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             authProvider = authenticationProvider ?? throw new ArgumentNullException(nameof(authenticationProvider));
             createdClient = httpClient == null;
             client = httpClient ?? KiotaClientFactory.Create();
-            BaseUrl = client.BaseAddress.ToString();
+            BaseUrl = client.BaseAddress?.ToString();
             pNodeFactory = parseNodeFactory ?? ParseNodeFactoryRegistry.DefaultInstance;
             sWriterFactory = serializationWriterFactory ?? SerializationWriterFactoryRegistry.DefaultInstance;
             obsOptions = observabilityOptions ?? new ObservabilityOptions();

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Fixes [Blazor WASM client unable to send web requests through HttpClient BaseAddress microsoft/kiota-http-dotnet#109](https://github.com/microsoft/kiota-http-dotnet/issues/109)

This change allows clients to propagate the BaseUrl through the RequestAdapter's supplied HttpClient instead of needing to set that property explicitly.