### PR TITLE
Fixes null reference when template is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2023-06-15
+
+- Fixes a bug where NullReference Exception is thrown if a requestInformation is sent without providing UriTemplate
+- RequestAdapter passes `HttpCompletionOption.ResponseHeadersRead` to HttpClient for Stream responses to avoid memory consumption for large payloads.
+
 ## [1.0.3] - 2023-06-09
 
 - Added propagating the HttpClientRequestAdapter's supplied HttpClient BaseAddress as the adapter's initial BaseUrl

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -201,7 +201,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                     if(isStreamResponse)
                     {
                         var result = await response.Content.ReadAsStreamAsync();
-                        if (result.Length == 0) {
+                        if (result.CanSeek && result.Length == 0) {
                             result.Dispose();
                             return default;
                         }

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Closes #110 to allow passing of `HttpCompletionOption.ResponseHeadersRead` to HttpClient for Stream responses
Closes #111 by fixing null reference exception observed when the UriTemplate is not set/null