### PR TITLE
Trim base url end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2023-06-29
+
+- Fixes regression in request building when the passed httpClient base address ends with a `\`
+
 ## [1.0.4] - 2023-06-15
 
 - Fixes a bug where NullReference Exception is thrown if a requestInformation is sent without providing UriTemplate

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/RequestAdapterTests.cs
@@ -36,6 +36,30 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         }
 
         [Fact]
+        public void BaseUrlIsSetAsExpected()
+        {
+            var httpClientRequestAdapter = new HttpClientRequestAdapter(_authenticationProvider);
+            Assert.Null(httpClientRequestAdapter.BaseUrl);// url is null
+
+            httpClientRequestAdapter.BaseUrl = "https://graph.microsoft.com/v1.0";
+            Assert.Equal("https://graph.microsoft.com/v1.0", httpClientRequestAdapter.BaseUrl);// url is set as expected
+
+            httpClientRequestAdapter.BaseUrl = "https://graph.microsoft.com/v1.0/";
+            Assert.Equal("https://graph.microsoft.com/v1.0", httpClientRequestAdapter.BaseUrl);// url is does not have the last `/` character
+        }
+
+        [Fact]
+        public void BaseUrlIsSetFromHttpClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri("https://graph.microsoft.com/v1.0/");
+            var httpClientRequestAdapter = new HttpClientRequestAdapter(_authenticationProvider, httpClient: httpClient);
+
+            Assert.NotNull(httpClientRequestAdapter.BaseUrl);// url is not null
+            Assert.Equal("https://graph.microsoft.com/v1.0", httpClientRequestAdapter.BaseUrl);// url is does not have the last `/` character
+        }
+
+        [Fact]
         public void EnablesBackingStore()
         {
             // Arrange

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -31,6 +31,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         private readonly IAuthenticationProvider authProvider;
         private IParseNodeFactory pNodeFactory;
         private ISerializationWriterFactory sWriterFactory;
+        private string? baseUrl;
         private readonly bool createdClient;
         private readonly ObservabilityOptions obsOptions;
         private readonly ActivitySource activitySource;
@@ -64,7 +65,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// <summary>
         /// The base url for every request.
         /// </summary>
-        public string? BaseUrl { get; set; }
+        public string? BaseUrl
+        {
+            get => baseUrl;
+            set => this.baseUrl = value?.TrimEnd('/');
+        }
         private static readonly char[] charactersToDecodeForUriTemplate = new char[] { '$', '.', '-', '~' };
         private static readonly Regex queryParametersCleanupRegex = new (@"\{\?[^\}]+}", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Singleline, TimeSpan.FromMilliseconds(100));
         private Activity? startTracingSpan(RequestInformation requestInfo, string methodName) {

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Ensure the set baseUrl does not end with `\` to avoid incorrect url building.

Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1993#issuecomment-1612497330