### PR TITLE
Fixes a bug where empty streams would be passed to the serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2023-07-06
+
+- Fixes a bug where empty streams would be passed to the serializers if the response content header is set. 
+
 ## [1.0.5] - 2023-06-29
 
 - Fixes regression in request building when the passed httpClient base address ends with a `\`

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -399,6 +399,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             if(string.IsNullOrEmpty(responseContentType))
                 return null;
             using var contentStream = await (response.Content?.ReadAsStreamAsync() ?? Task.FromResult(Stream.Null));
+            if(contentStream == Stream.Null || (contentStream.CanSeek && contentStream.Length == 0))
+                return null;// ensure a usefule stream is passed to the factory
             var rootNode = pNodeFactory.GetRootParseNode(responseContentType!, contentStream);
             return rootNode;
         }

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.5</VersionPrefix>
+    <VersionPrefix>1.0.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2000

Ensures that streams passed to the `parseNodeFactory` is usable to avoid serialization failures when we should ideally return null. 