### PR TITLE
Fixes the paramDecodingHandler to only decode query parameter names

### DIFF
--- a/.github/workflows/build-and_test.yml
+++ b/.github/workflows/build-and_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest # Temporary switch to windows till https://github.com/microsoft/vstest/issues/4549 is released in dotnet version after 7.0.400
     env:
       solutionName: Microsoft.Kiota.Http.HttpClientLibrary.sln
     steps:
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 7.0.307 # Lock down version till https://github.com/microsoft/vstest/issues/4549 is released
+          dotnet-version: 7.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2023-08-28
+
+- Fixes a bug where the `ParametersNameDecodingHandler` would also decode query parameter values.
+
 ## [1.1.0] - 2023-08-11
 
 ### Added

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/ParametersNameDecodingHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/ParametersNameDecodingHandlerTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Xunit;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware;
@@ -28,6 +30,8 @@ public class ParametersDecodingHandlerTests
     [InlineData("http://localhost/path%2dsegment?%24select=diplayName&api%2Dversion=2", "http://localhost/path-segment?$select=diplayName&api-version=2")] //it's URI decoding the path segment
     [InlineData("http://localhost:888?%24select=diplayName&api%2Dversion=2", "http://localhost:888/?$select=diplayName&api-version=2")]
     [InlineData("http://localhost", "http://localhost/")]
+    [InlineData("https://google.com/?q=1%2b2", "https://google.com/?q=1%2b2")]
+    [InlineData("https://google.com/?q=M%26A", "https://google.com/?q=M%26A")]
     [Theory]
     public async Task DefaultParameterNameDecodingHandlerDecodesNames(string original, string result)
     {
@@ -41,9 +45,48 @@ public class ParametersDecodingHandlerTests
         var requestMessage = await requestAdapter.ConvertToNativeRequestAsync<HttpRequestMessage>(requestInfo);
 
         // Act
-        var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+        await _invoker.SendAsync(requestMessage, new CancellationToken());
 
         // Assert the request stays the same
-        Assert.Equal(result, requestMessage.RequestUri.ToString());
+        Assert.Equal(result, requestMessage.RequestUri!.ToString());
+    }
+
+    [InlineData("http://localhost?%24select=diplayName&api%2Dversion=2", "http://localhost/?$select=diplayName&api-version=2")]
+    [InlineData("http://localhost?%24select=diplayName&api%7Eversion=2", "http://localhost/?$select=diplayName&api~version=2")]
+    [InlineData("http://localhost?%24select=diplayName&api%2Eversion=2", "http://localhost/?$select=diplayName&api.version=2")]
+    [InlineData("http://localhost/path%2dsegment?%24select=diplayName&api%2Dversion=2", "http://localhost/path-segment?$select=diplayName&api-version=2")] //it's URI decoding the path segment
+    [InlineData("http://localhost:888?%24select=diplayName&api%2Dversion=2", "http://localhost:888/?$select=diplayName&api-version=2")]
+    [InlineData("http://localhost", "http://localhost/")]
+    [InlineData("https://google.com/?q=1%2B2", "https://google.com/?q=1%2B2")]//Values are not decoded
+    [InlineData("https://google.com/?q=M%26A", "https://google.com/?q=M%26A")]//Values are not decoded
+    [InlineData("https://google.com/?q%2D1=M%26A", "https://google.com/?q-1=M%26A")]//Values are not decoded but params are
+    [InlineData("https://google.com/?q%2D1&q=M%26A=M%26A", "https://google.com/?q-1&q=M%26A=M%26A")]//Values are not decoded but params are
+    [Theory]
+    public async Task DefaultParameterNameDecodingHandlerDecodesNamesWithMeaningFullUrlCharacters(string original, string result)
+    {
+        // Arrange
+        var requestInfo = new RequestInformation
+        {
+            HttpMethod = Method.GET,
+            URI = new Uri(original)
+        };
+        requestInfo.AddRequestOptions(new []
+        {
+            new ParametersNameDecodingOption
+            {
+                ParametersToDecode = new List<char>
+                {
+                    '$','.', '-', '~', '+','&' // Add custom options for testing purposes
+                }
+            }
+        });
+        // Act and get a request message
+        var requestMessage = await requestAdapter.ConvertToNativeRequestAsync<HttpRequestMessage>(requestInfo);
+
+        // Act
+        await _invoker.SendAsync(requestMessage, new CancellationToken());
+
+        // Assert the request stays the same
+        Assert.Equal(result, requestMessage.RequestUri!.ToString());
     }
 }

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/src/Middleware/ParametersNameDecodingHandler.cs
+++ b/src/Middleware/ParametersNameDecodingHandler.cs
@@ -39,7 +39,7 @@ public class ParametersNameDecodingHandler: DelegatingHandler
         Activity? activity;
         if (request.GetRequestOption<ObservabilityOptions>() is ObservabilityOptions obsOptions) {
             activitySource = new ActivitySource(obsOptions.TracerInstrumentationName);
-            activity = activitySource?.StartActivity($"{nameof(ParametersNameDecodingHandler)}_{nameof(SendAsync)}");
+            activity = activitySource.StartActivity($"{nameof(ParametersNameDecodingHandler)}_{nameof(SendAsync)}");
             activity?.SetTag("com.microsoft.kiota.handler.parameters_name_decoding.enable", true);
         } else {
             activity = null;
@@ -47,7 +47,6 @@ public class ParametersNameDecodingHandler: DelegatingHandler
         }
         try {
             if(!request.RequestUri!.Query.Contains('%') ||
-                options == null ||
                 !options.Enabled ||
                 !(options.ParametersToDecode?.Any() ?? false))
             {


### PR DESCRIPTION
Closes https://github.com/microsoft/kiota-http-dotnet/issues/137

Also fixes incorrect parameter passed to `DecodeUriEncodedString` to to allow for per request configuration as opposed to the clalss value `EncodingOptions.ParametersToDecode`