### PR TITLE
Fixes a bug with `CloneAsync` extension method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2023-11-28
+
+### Added
+
+- Fixes a bug with internal `CloneAsync` method when using stream content types.
+
 ## [1.3.2] - 2023-11-15
 
 ### Added

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -67,17 +67,39 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Extensions
                 HttpMethod = Method.GET,
                 URI = new Uri("http://localhost")
             };
-            requestInfo.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes("contents")), "application/octet-stream");
             var originalRequest = await requestAdapter.ConvertToNativeRequestAsync<HttpRequestMessage>(requestInfo);
             originalRequest.Content = new StringContent("contents");
 
             var clonedRequest = await originalRequest.CloneAsync();
+            var originalContents = await originalRequest.Content.ReadAsStringAsync();
             var clonedRequestContents = await clonedRequest.Content?.ReadAsStringAsync();
 
             Assert.NotNull(clonedRequest);
             Assert.Equal(originalRequest.Method, clonedRequest.Method);
             Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
-            Assert.Equal("contents", clonedRequestContents);
+            Assert.Equal(originalContents, clonedRequestContents);
+            Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
+        }
+
+        [Fact]
+        public async Task CloneAsyncWithHttpStreamContent()
+        {
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                URI = new Uri("http://localhost")
+            };
+            requestInfo.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes("contents")), "application/octet-stream");
+            var originalRequest = await requestAdapter.ConvertToNativeRequestAsync<HttpRequestMessage>(requestInfo);
+
+            var clonedRequest = await originalRequest.CloneAsync();
+            var originalContents = await originalRequest.Content.ReadAsStringAsync();
+            var clonedRequestContents = await clonedRequest.Content?.ReadAsStringAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.Equal(originalContents, clonedRequestContents);
             Assert.Equal(originalRequest.Content?.Headers.ContentType, clonedRequest.Content?.Headers.ContentType);
         }
 

--- a/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Extensions/HttpRequestMessageExtensions.cs
@@ -70,10 +70,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Extensions
             if(originalRequest.Content != null)
             {
                 // HttpClient doesn't rewind streams and we have to explicitly do so.
+                var contentStream = new MemoryStream();
 #if NET5_0_OR_GREATER
-                var contentStream = await originalRequest.Content.ReadAsStreamAsync(cancellationToken);
+                await originalRequest.Content.CopyToAsync(contentStream, cancellationToken);
 #else
-                var contentStream = await originalRequest.Content.ReadAsStreamAsync();
+                await originalRequest.Content.CopyToAsync(contentStream);
 #endif
 
                 if(contentStream.CanSeek)

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.2</VersionPrefix>
+    <VersionPrefix>1.3.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
The `CloneAsync` extension method for `HttpRequestMessage` calls `ReadAsStreamAsync` to get the stream contents of a request when cloning the request which will simply [return the same underlying stream](https://github.com/dotnet/runtime/blob/f38242bd94e4ba67c8b985ffe4d52bd04cc2a36c/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L262) object of the request message. 
This therefore means that disposing or seeking the content of the original object will also affect the content of the cloned object as well.

This PR therefore fixes the implementation to use `CopyToAsync` so that a new copy is created to avoid unintended consequences when working with the clone or the original. Tests have been added to validate this as well. 
