### PR TITLE
Add more information on failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.8] - 2024-03-25]
+
+## Changed
+
+- When too many retries are attempted, the RetryHandler will now throw an `AggregateException` (instead of an `InvalidOperationException`).
+  The `InnerExceptions` property of the `AggregateException` will contain a list of `ApiException` with the HTTP status code and an error message if available.
+
 ## [1.3.7] - 2024-02-26
 
 ### Changed

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RetryHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RetryHandlerTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.IsType<RetryHandler>(retry);
         }
 
-
         [Fact]
         public void RetryHandlerHttpMessageHandlerConstructor()
         {
@@ -89,7 +88,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.NotNull(response.RequestMessage);
             Assert.Same(response.RequestMessage, httpRequestMessage);
             Assert.False(response.RequestMessage.Headers.Contains(RetryAttempt), "The request add header wrong.");
-
         }
 
         [Theory]
@@ -116,7 +114,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Equal(values.First(), 1.ToString());
         }
 
-
         [Theory]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
@@ -140,7 +137,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.NotNull(response.RequestMessage.Content);
             Assert.NotNull(response.RequestMessage.Content.Headers.ContentLength);
             Assert.Equal("Hello World", await response.RequestMessage.Content.ReadAsStringAsync());
-
         }
 
         [Theory]
@@ -196,7 +192,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Equal(response.RequestMessage.Content.Headers.ContentLength, -1);
         }
 
-
         [Theory(Skip = "Test takes a while to run")]
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
@@ -246,15 +241,14 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Arrange
             var retryResponse = new HttpResponseMessage(statusCode);
             var futureTime = DateTime.Now + TimeSpan.FromSeconds(3);// 3 seconds from now
-            var futureTimeString = futureTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.RFC1123Pattern);
+            var futureTimeString = futureTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.RFC1123Pattern, CultureInfo.InvariantCulture);
             Assert.Contains("GMT", futureTimeString); // http date always end in GMT according to the spec
-            retryResponse.Headers.TryAddWithoutValidation(RetryAfter, futureTimeString);
+            Assert.True(retryResponse.Headers.TryAddWithoutValidation(RetryAfter, futureTimeString));
             // Act
             await DelayTestWithMessage(retryResponse, 1, "Init");
             // Assert
             Assert.Equal("Init Work 1", Message);
         }
-
 
         [Theory(Skip = "Skipped as this takes 9 minutes to run for each scenario")] // Takes 9 minutes to run for each scenario
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
@@ -351,7 +345,6 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
         }
 
-
         [Theory]
         [InlineData(1, HttpStatusCode.BadGateway, true)]
         [InlineData(2, HttpStatusCode.BadGateway, true)]
@@ -411,14 +404,16 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             catch(Exception exception)
             {
                 // Assert
-                Assert.IsType<InvalidOperationException>(exception);
+                Assert.IsType<AggregateException>(exception);
+                var aggregateException = exception as AggregateException;
                 Assert.True(isExceptionExpected);
-                Assert.Equal("Too many retries performed", exception.Message);
+                Assert.StartsWith("Too many retries performed.", aggregateException.Message);
+                Assert.Equal(1 + expectedMaxRetry, aggregateException.InnerExceptions.Count);
+                Assert.All(aggregateException.InnerExceptions, innerexception => Assert.Contains(expectedStatusCode.ToString(), innerexception.Message));
             }
 
             // Assert
             mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1 + expectedMaxRetry), ItExpr.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>());
-
         }
 
         private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message, int delay = RetryHandlerOption.MaxDelay)

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RetryHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/RetryHandlerTests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Tests.Mocks;
@@ -220,6 +221,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 Assert.IsType<AggregateException>(exception);
                 var aggregateException = exception as AggregateException;
                 Assert.StartsWith("Too many retries performed.", aggregateException.Message);
+                Assert.All(aggregateException.InnerExceptions, innerexception => Assert.IsType<ApiException>(innerexception));
+                Assert.All(aggregateException.InnerExceptions, innerexception => Assert.True((innerexception as ApiException).ResponseStatusCode == (int)statusCode));
                 Assert.False(httpRequestMessage.Headers.TryGetValues(RetryAttempt, out _), "Don't set Retry-Attempt Header");
             }
         }

--- a/Microsoft.Kiota.Http.HttpClientLibrary.sln
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.sln
@@ -1,18 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34714.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Kiota.Http.HttpClientLibrary", "src\Microsoft.Kiota.Http.HttpClientLibrary.csproj", "{769E84B2-FD14-4173-B83B-6792DFB0BA14}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{178B3904-FBB4-4E5A-A569-B5082BABC124}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		CHANGELOG.md = CHANGELOG.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Kiota.Http.HttpClientLibrary.Tests", "Microsoft.Kiota.Http.HttpClientLibrary.Tests\Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj", "{CCD20728-D593-48F8-8627-6E7A57B31A43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Kiota.Http.HttpClientLibrary.Tests", "Microsoft.Kiota.Http.HttpClientLibrary.Tests\Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj", "{CCD20728-D593-48F8-8627-6E7A57B31A43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KiotaGenerated", "Kiota.Generated\KiotaGenerated.csproj", "{6667C82F-EFF1-4D7C-828D-F981629C8256}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KiotaGenerated", "Kiota.Generated\KiotaGenerated.csproj", "{6667C82F-EFF1-4D7C-828D-F981629C8256}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.7</VersionPrefix>
+    <VersionPrefix>1.3.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
         private static async Task<Exception> GetInnerException(HttpResponseMessage response, CancellationToken cancellationToken)
         {
             var httpStatusCode = response.StatusCode;
-            var errorMessage = "The response has not content.";
+            string? errorMessage = null;
 
             // Drain response content to free connections. Need to perform this
             // before retry attempt and before the TooManyRetries ServiceException.
@@ -248,7 +248,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
                 errorMessage = GetStringFromContent(responseContent);
             }
 
-            return new Exception($"HTTP request failed with status code: {httpStatusCode}. Error Message: {errorMessage}");
+            return new Exception($"HTTP request failed with status code: {httpStatusCode}.{errorMessage}");
         }
 
         private static string GetStringFromContent(byte[] content)

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
 
             exceptions.Add(await GetInnerException(response, cancellationToken));
 
-            throw new AggregateException("Too many retries performed.", exceptions);
+            throw new AggregateException($"Too many retries performed. More than {retryCount} retries encountered while sending the request.", exceptions);
         }
 
         /// <summary>

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -250,7 +250,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
                 errorMessage = GetStringFromContent(responseContent);
             }
 
-            return new Exception($"HTTP request failed with status code: {httpStatusCode}.{errorMessage}");
+            return new ApiException($"HTTP request failed with status code: {httpStatusCode}.{errorMessage}")
+            {
+                ResponseStatusCode = (int)response.StatusCode,
+                ResponseHeaders = response.Headers.ToDictionary()
+            };
         }
 
         private static string GetStringFromContent(byte[] content)

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -231,7 +231,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             };
         }
 
-        private static async Task<Exception> GetInnerException(HttpResponseMessage response, CancellationToken cancellationToken)
+        private static async Task<Exception> GetInnerExceptionAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+
         {
             var httpStatusCode = response.StatusCode;
             string? errorMessage = null;

--- a/src/Middleware/RetryHandler.cs
+++ b/src/Middleware/RetryHandler.cs
@@ -242,9 +242,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             if(response.Content != null)
             {
 #if NET5_0_OR_GREATER
-                var responseContent = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                errorMessage = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
-                var responseContent = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                errorMessage = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
 #endif
                 errorMessage = GetStringFromContent(responseContent);
             }


### PR DESCRIPTION
The SendAsync method will now throw an AggregateException exception instead of an InvalidOperationException when too many retries are made. Each inner exception is an Exception with the HTTP Status Code and the response content, if available.