### PR TITLE
Fixes release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -251,7 +251,7 @@ extends:
                     filePath: $(Pipeline.Workspace)\scripts\GetNugetPackageVersion.ps1
                     pwsh: true
                     arguments: '-packageDirPath "$(Pipeline.Workspace)/"'
-                - task: NuGetCommand@2
+                - task: 1ES.PublishNuGet@1
                   displayName: 'NuGet push'
                   inputs:
                     command: push


### PR DESCRIPTION
Follow up to https://github.com/microsoft/kiota-http-dotnet/pull/214

Fixes deploy task to use compliant `1ES.PublishNuGet@1` task