### PR TITLE
Fixes errors in NetFramework for http/2 scenarions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.11] - 2024-04-19
+
+## Changed
+
+- Fixes default handler for NET framework to unlock HTTP/2 scenarios (https://github.com/microsoft/kiota-http-dotnet/issues/237)
+
 ## [1.3.10] - 2024-04-19
 
 ## Changed

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -73,8 +73,13 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             var defaultHandler = KiotaClientFactory.GetDefaultHttpMessageHandler(proxy);
             // Assert
             Assert.NotNull(defaultHandler);
+#if NETFRAMEWORK
+            Assert.IsType<WinHttpHandler>(defaultHandler);
+            Assert.Equal(proxy, ((WinHttpHandler)defaultHandler).Proxy);
+#else
             Assert.IsType<HttpClientHandler>(defaultHandler);
             Assert.Equal(proxy, ((HttpClientHandler)defaultHandler).Proxy);
+#endif
 
         }
     }

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -83,7 +83,14 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// <returns/>
         public static HttpMessageHandler GetDefaultHttpMessageHandler(IWebProxy? proxy = null)
         {
+#if NETFRAMEWORK
+            // If custom proxy is passed, the WindowsProxyUsePolicy will need updating
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs#L575
+            var proxyPolicy = proxy != null ? WindowsProxyUsePolicy.UseCustomProxy : WindowsProxyUsePolicy.UseWinHttpProxy;
+            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy, SendTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveDataTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = System.Threading.Timeout.InfiniteTimeSpan };
+#else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
+#endif
         }
     }
 }

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Kiota Http Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
     <!-- NET 5 target to be removed on next major version-->
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net8.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.10</VersionPrefix>
+    <VersionPrefix>1.3.11</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -48,11 +48,13 @@
   </ItemGroup>
 
   <!-- NET 5 target to be removed on next major version-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6.0,9.0)" />
     <PackageReference Include="System.Text.Json" Version="[6.0,9.0)" />
   </ItemGroup>
-
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="[6.0,9.0)" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kiota.Generated\KiotaGenerated.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #237 

Enables `WinHttpHandler` as default final handler to unlock http/2 scenarions in Http/2