### PR TITLE
UriReplacementHandler improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.12] - 2024-04-22
+
+- UriReplacementHandler improvements to be added to middleware pipeline by default and respects options set in the HttpRequestMessage (https://github.com/microsoft/kiota-http-dotnet/issues/242)
 - Adds `ConfigureAwait(false)` calls to async calls (https://github.com/microsoft/kiota-http-dotnet/issues/240). 
 
 ## [1.3.11] - 2024-04-19

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/UriReplacementHandlerTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/Middleware/UriReplacementHandlerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using Moq;
@@ -64,5 +65,39 @@ public class UriReplacementHandlerTests
         await client.SendAsync(msg);
 
         mockReplacement.Verify(static x=> x.Replace(It.IsAny<Uri>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task Calls_Uri_Replacement_From_Request_OptionsAsync()
+    {
+        var mockReplacement = new Mock<IUriReplacementHandlerOption>();
+        mockReplacement.Setup(static x => x.IsEnabled()).Returns(true);
+        mockReplacement.Setup(static x => x.Replace(It.IsAny<Uri>())).Returns(new Uri("http://changed"));
+
+        var handler = new UriReplacementHandler<IUriReplacementHandlerOption>()
+        {
+            InnerHandler = new FakeSuccessHandler()
+        };
+        var msg = new HttpRequestMessage(HttpMethod.Get, "http://localhost");
+        SetRequestOption(msg, mockReplacement.Object);
+        var client = new HttpClient(handler);
+        await client.SendAsync(msg);
+
+        mockReplacement.Verify(static x=> x.Replace(It.IsAny<Uri>()), Times.Once());
+    }
+
+    /// <summary>
+    /// Sets a <see cref="IRequestOption"/> in <see cref="HttpRequestMessage"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="httpRequestMessage">The <see cref="HttpRequestMessage"/> representation of the request.</param>
+    /// <param name="option">The request option.</param>
+    private static void SetRequestOption<T>(HttpRequestMessage httpRequestMessage, T option) where T : IRequestOption
+    {
+#if NET5_0_OR_GREATER
+        httpRequestMessage.Options.Set(new HttpRequestOptionsKey<T>(typeof(T).FullName!), option);
+#else
+        httpRequestMessage.Properties.Add(typeof(T).FullName!, option);
+#endif
     }
 }

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary
 {
@@ -36,6 +37,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             return new List<DelegatingHandler>
             {
                 //add the default middlewares as they are ready
+                new UriReplacementHandler<UriReplacementHandlerOption>(),
                 new RetryHandler(),
                 new RedirectHandler(),
                 new ParametersNameDecodingHandler(),

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.11</VersionPrefix>
+    <VersionPrefix>1.3.12</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Closes #242 assuming it's ideal for `UriReplacementHandler` to be useable out of the box the way the rest of the handlers are, with the following changes:

1. `UriReplacementHandler` respects options set in the `HttpRequestMessage` in addition to an option given to it upon construction. A test is also added for this.
2. `UriReplacementHandler<UriReplacementHandlerOption>` is included as a default handler so it doesn't have to be added manually.