### PR TITLE
Add KiotaClientFactory `create()` overload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Mono auto generated files
 mono_crash.*
+.mono/
 
 # Build results
 [Dd]ebug/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0]
+
+## Added
+
+- KiotaClientFactory `create()` overload that accepts a list of handlers.
+
 ## [1.3.12] - 2024-04-22
 
 - UriReplacementHandler improvements to be added to middleware pipeline by default and respects options set in the HttpRequestMessage (https://github.com/microsoft/kiota-http-dotnet/issues/242)

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         public void CreateWithCustomMiddlewarePipelineReturnsHttpClient()
         {
             var handlers = KiotaClientFactory.CreateDefaultHandlers();
-            handlers.Append(new CompressionHandler());
+            handlers.Add(new CompressionHandler());
             var client = KiotaClientFactory.Create(handlers);
             Assert.IsType<HttpClient>(client);
         }

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
@@ -88,7 +90,10 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [Fact]
         public void CreateWithNullOrEmptyHandlersReturnsHttpClient()
         {
-            var client = KiotaClientFactory.Create(null);
+            var client = KiotaClientFactory.Create(null, null);
+            Assert.IsType<HttpClient>(client);
+
+            client = KiotaClientFactory.Create(new List<DelegatingHandler>());
             Assert.IsType<HttpClient>(client);
         }
 

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Net.Http;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
 using Microsoft.Kiota.Http.HttpClientLibrary.Tests.Mocks;
 using Xunit;
 
@@ -81,6 +83,22 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             Assert.Equal(proxy, ((HttpClientHandler)defaultHandler).Proxy);
 #endif
 
+        }
+
+        [Fact]
+        public void CreateWithNullOrEmptyHandlersReturnsHttpClient()
+        {
+            var client = KiotaClientFactory.Create(null);
+            Assert.IsType<HttpClient>(client);
+        }
+
+        [Fact]
+        public void CreateWithCustomMiddlewarePipelineReturnsHttpClient()
+        {
+            var handlers = KiotaClientFactory.CreateDefaultHandlers();
+            handlers.Append(new CompressionHandler());
+            var client = KiotaClientFactory.Create(handlers);
+            Assert.IsType<HttpClient>(client);
         }
     }
 }

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -28,6 +28,21 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             var handler = ChainHandlersCollectionAndGetFirstLink(finalHandler ?? GetDefaultHttpMessageHandler(), defaultHandlers.ToArray());
             return handler != null ? new HttpClient(handler) : new HttpClient();
         }
+
+        /// <summary>
+        /// Initializes the <see cref="HttpClient"/> with a custom middleware pipeline.
+        /// </summary>
+        /// <param name="handlers">The <see cref="DelegatingHandler"/> instances to create the <see cref="DelegatingHandler"/> from.</param>
+        /// <param name="finalHandler">The final <see cref="HttpMessageHandler"/> in the http pipeline. Can be configured for proxies, auto-decompression and auto-redirects</param>
+        /// <returns>The <see cref="HttpClient"/> with the custom handlers.</returns>
+        public static HttpClient Create(IList<DelegatingHandler> handlers, HttpMessageHandler? finalHandler = null)
+        {
+            if(handlers == null || !handlers.Any())
+                return Create(finalHandler);
+            var handler = ChainHandlersCollectionAndGetFirstLink(finalHandler ?? GetDefaultHttpMessageHandler(), handlers.ToArray());
+            return handler != null ? new HttpClient(handler) : new HttpClient();
+        }
+
         /// <summary>
         /// Creates a default set of middleware to be used by the <see cref="HttpClient"/>.
         /// </summary>

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.12</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Overloads `create()` to allow passing middleware pipeline list.

closes https://github.com/microsoft/kiota-http-dotnet/issues/144