### PR TITLE
Use SocketsHttpHandler and EnableMultipleHttp2Connections as default handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.12] - 2024-04-22
 
 - UriReplacementHandler improvements to be added to middleware pipeline by default and respects options set in the HttpRequestMessage (https://github.com/microsoft/kiota-http-dotnet/issues/242)
-- Adds `ConfigureAwait(false)` calls to async calls (https://github.com/microsoft/kiota-http-dotnet/issues/240).
+- Adds `ConfigureAwait(false)` calls to async calls (https://github.com/microsoft/kiota-http-dotnet/issues/240). 
 
 ## [1.3.11] - 2024-04-19
 
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Have made System.\* dependencies only be included on Net Standard's TFM & net 5 (https://github.com/microsoft/kiota-http-dotnet/issues/230)
+- Have made System.* dependencies only be included on Net Standard's TFM & net 5 (https://github.com/microsoft/kiota-http-dotnet/issues/230)
 
 ## [1.3.9] - 2024-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2024-05-07
+
+## Changed
+
+- Use `SocketsHttpHandler` with `EnableMultipleHttp2Connections` as default HTTP message handler.
+
 ## [1.4.0]
 
 ## Added
@@ -16,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.12] - 2024-04-22
 
 - UriReplacementHandler improvements to be added to middleware pipeline by default and respects options set in the HttpRequestMessage (https://github.com/microsoft/kiota-http-dotnet/issues/242)
-- Adds `ConfigureAwait(false)` calls to async calls (https://github.com/microsoft/kiota-http-dotnet/issues/240). 
+- Adds `ConfigureAwait(false)` calls to async calls (https://github.com/microsoft/kiota-http-dotnet/issues/240).
 
 ## [1.3.11] - 2024-04-19
 
@@ -28,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Have made System.* dependencies only be included on Net Standard's TFM & net 5 (https://github.com/microsoft/kiota-http-dotnet/issues/230)
+- Have made System.\* dependencies only be included on Net Standard's TFM & net 5 (https://github.com/microsoft/kiota-http-dotnet/issues/230)
 
 ## [1.3.9] - 2024-04-17
 

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -71,10 +71,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [Fact]
         public void GetDefaultHttpMessageHandlerEnablesMultipleHttp2Connections()
         {
-            // Arrange
-            var proxy = new WebProxy("http://localhost:8888", false);
             // Act
-            var defaultHandler = KiotaClientFactory.GetDefaultHttpMessageHandler(proxy);
+            var defaultHandler = KiotaClientFactory.GetDefaultHttpMessageHandler();
             // Assert
             Assert.NotNull(defaultHandler);
 #if NETFRAMEWORK

--- a/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
+++ b/Microsoft.Kiota.Http.HttpClientLibrary.Tests/KiotaClientFactoryTests.cs
@@ -69,6 +69,24 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         }
 
         [Fact]
+        public void GetDefaultHttpMessageHandlerEnablesMultipleHttp2Connections()
+        {
+            // Arrange
+            var proxy = new WebProxy("http://localhost:8888", false);
+            // Act
+            var defaultHandler = KiotaClientFactory.GetDefaultHttpMessageHandler(proxy);
+            // Assert
+            Assert.NotNull(defaultHandler);
+#if NETFRAMEWORK
+            Assert.IsType<WinHttpHandler>(defaultHandler);
+            Assert.True(((WinHttpHandler)defaultHandler).EnableMultipleHttp2Connections);
+#else
+            Assert.IsType<SocketsHttpHandler>(defaultHandler);
+            Assert.True(((SocketsHttpHandler)defaultHandler).EnableMultipleHttp2Connections);
+#endif
+        }
+
+        [Fact]
         public void GetDefaultHttpMessageHandlerSetsUpProxy()
         {
             // Arrange
@@ -81,10 +99,9 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             Assert.IsType<WinHttpHandler>(defaultHandler);
             Assert.Equal(proxy, ((WinHttpHandler)defaultHandler).Proxy);
 #else
-            Assert.IsType<HttpClientHandler>(defaultHandler);
-            Assert.Equal(proxy, ((HttpClientHandler)defaultHandler).Proxy);
+            Assert.IsType<SocketsHttpHandler>(defaultHandler);
+            Assert.Equal(proxy, ((SocketsHttpHandler)defaultHandler).Proxy);
 #endif
-
         }
 
         [Fact]

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -104,7 +104,9 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
             // If custom proxy is passed, the WindowsProxyUsePolicy will need updating
             // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs#L575
             var proxyPolicy = proxy != null ? WindowsProxyUsePolicy.UseCustomProxy : WindowsProxyUsePolicy.UseWinHttpProxy;
-            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy, SendTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveDataTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = System.Threading.Timeout.InfiniteTimeSpan };
+            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None, WindowsProxyUsePolicy = proxyPolicy, SendTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveDataTimeout = System.Threading.Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = System.Threading.Timeout.InfiniteTimeSpan, EnableMultipleHttp2Connections = true };
+#elif NET5_0_OR_GREATER
+            return new SocketsHttpHandler { Proxy = proxy, AllowAutoRedirect = false, EnableMultipleHttp2Connections = true };
 #else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
 #endif

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
`SocketsHttpHandler` has been the default handler of `HttpClientHandler` since .NET 5. This change uses `SocketsHttpHandler` directly from Kiota, without going through `HttpClientHandler`.

This change also enables `EnableMultipleHttp2Connections`, which improves performance when there are over 100 concurrent requests to the same server.

This can be performance tested by starting a HTTP/2 server that holds connections open for some time, and a client which makes over 100 parallel requests. e.g.

server:
```csharp
var builder = WebApplication.CreateBuilder(args);
builder.WebHost.ConfigureKestrel(k =>
    k.ConfigureEndpointDefaults(e =>
        e.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1AndHttp2));
var app = builder.Build();
app.MapGet("/", () => Task.Delay(100));
app.Run();
```

client:
```csharp
var client = new ApiSdk.ApiClient(new HttpClientRequestAdapter(new AnonymousAuthenticationProvider())
{ BaseUrl = "https://localhost:5001" });

await client.GetAsync(); // warm up

var stopwatch = Stopwatch.StartNew();
await Parallel.ForEachAsync(
    Enumerable.Range(0, 10_000),
    new ParallelOptions { MaxDegreeOfParallelism = 200 },
    async (_, cancel) => await client.GetAsync(cancellationToken: cancel));
stopwatch.Stop();
Console.WriteLine(stopwatch.Elapsed);
```

This causes performance to continue to scale when there are over 100 connections rather than stop scaling at 100 connections. There doesn't seem to be any performance impact, positive or negative, below 100 connections.

fixes https://github.com/microsoft/kiota-http-dotnet/issues/239