### PR TITLE
Access to just the types of the handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `GetDefaultHandlerTypes` added to `KiotaClientFactory` if you're creating your own `HttpClient` and still want to use the default handlers.
+
 ## [1.4.1] - 2024-05-07
 
 ## Changed

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         {
             return new List<DelegatingHandler>
             {
-                //add the default middlewares as they are ready
+                //add the default middlewares as they are ready, and add them to the list above as well
                 new UriReplacementHandler<UriReplacementHandlerOption>(),
                 new RetryHandler(),
                 new RedirectHandler(),
@@ -60,6 +60,25 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 new HeadersInspectionHandler(),
             };
         }
+
+        /// <summary>
+        /// Gets the default handler types.
+        /// </summary>
+        /// <returns>A list of all the default handlers</returns>
+        /// <remarks>Order matters</remarks>
+        public static IList<System.Type> GetDefaultHandlerTypes()
+        {
+            return new List<System.Type>
+            {
+                typeof(UriReplacementHandler<UriReplacementHandlerOption>),
+                typeof(RetryHandler),
+                typeof(RedirectHandler),
+                typeof(ParametersNameDecodingHandler),
+                typeof(UserAgentHandler),
+                typeof(HeadersInspectionHandler),
+            };
+        }
+
         /// <summary>
         /// Creates a <see cref="DelegatingHandler"/> to use for the <see cref="HttpClient" /> from the provided <see cref="DelegatingHandler"/> instances. Order matters.
         /// </summary>
@@ -81,7 +100,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 }
             }
             if(finalHandler != null)
-                handlers[handlers.Length-1].InnerHandler = finalHandler;
+                handlers[handlers.Length - 1].InnerHandler = finalHandler;
             return handlers[0];//first
         }
         /// <summary>
@@ -91,7 +110,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         /// <returns>The created <see cref="DelegatingHandler"/>.</returns>
         public static DelegatingHandler? ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
         {
-            return ChainHandlersCollectionAndGetFirstLink(null,handlers);
+            return ChainHandlersCollectionAndGetFirstLink(null, handlers);
         }
         /// <summary>
         /// Gets a default Http Client handler with the appropriate proxy configurations

--- a/src/KiotaClientFactory.cs
+++ b/src/KiotaClientFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         {
             return new List<DelegatingHandler>
             {
-                //add the default middlewares as they are ready, and add them to the list above as well
+                //add the default middlewares as they are ready, and add them to the list below as well
                 new UriReplacementHandler<UriReplacementHandlerOption>(),
                 new RetryHandler(),
                 new RedirectHandler(),

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.4.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/src/Middleware/Options/UriReplacementHandlerOption.cs
+++ b/src/Middleware/Options/UriReplacementHandlerOption.cs
@@ -43,6 +43,13 @@ public class UriReplacementHandlerOption : IUriReplacementHandlerOption
         this.replacementPairs = replacementPairs;
     }
 
+    /// <summary>
+    /// Creates a new instance of UriReplacementOption with no replacements.
+    /// </summary>
+    /// <param name="isEnabled">Whether replacement is enabled.</param>
+    /// <remarks>Replacement is disabled by default.</remarks>
+    public UriReplacementHandlerOption(bool isEnabled = false) : this(isEnabled, Array.Empty<KeyValuePair<string, string>>()) { }
+
     /// <inheritdoc/>
     public bool IsEnabled()
     {


### PR DESCRIPTION
Related to [this discussion](https://github.com/MicrosoftDocs/openapi-docs/pull/89#discussion_r1596686316) where I want to enable everybody to use dependency injection instead of the self implemented HttpClient factory.

I'm not sure if this code would be better, I don't like the dependency it takes on reflection. But it would reduce it to only have one list to keep.

```csharp
public static IList<DelegatingHandler> CreateDefaultHandlers()
{
    return GetDefaultHandlerTypes()
        .Select(handlerType => (DelegatingHandler)System.Activator.CreateInstance(handlerType))
        .ToList();
}
```

Fixed #254