### PR TITLE
SendPrimitiveAsync throws InvalidOperationException for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2024-06-21
+
+### Changed
+
+- Fixes handling enums by `SendPrimitiveAsync`
+
 ## [1.4.3] - 2024-05-24
 
 ### Changed

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -307,7 +307,19 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                                     break;
                                 }
                             }
-                            result = Enum.Parse(underlyingType, rawValue, true);
+#if NET5_0_OR_GREATER
+                            Enum.TryParse(underlyingType, rawValue, true, out object? enumResult);
+                            result = enumResult;
+#else
+                            try
+                            {
+                                result = Enum.Parse(underlyingType, rawValue, true);
+                            }
+                            catch
+                            {
+                                result = null;
+                            }
+#endif
                         }
                         else
                         {

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -293,7 +293,19 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                         {
                             result = rootNode.GetDateValue();
                         }
-                        else throw new InvalidOperationException("error handling the response, unexpected type");
+                        else
+                        {
+                            var underlyingType = Nullable.GetUnderlyingType(modelType);
+                            if(underlyingType != null && underlyingType.IsEnum)
+                            {
+                                var rawValue = rootNode.GetStringValue();
+                                result = Enum.Parse(underlyingType, rawValue!, true);
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException("error handling the response, unexpected type");
+                            }
+                        }
                         SetResponseType(result, span);
                         return (ModelType)result!;
                     }

--- a/src/HttpClientRequestAdapter.cs
+++ b/src/HttpClientRequestAdapter.cs
@@ -304,6 +304,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                                 if(field.GetCustomAttribute<EnumMemberAttribute>() is { } attr && rawValue.Equals(attr.Value, StringComparison.Ordinal))
                                 {
                                     rawValue = field.Name;
+                                    break;
                                 }
                             }
                             result = Enum.Parse(underlyingType, rawValue, true);

--- a/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.4.3</VersionPrefix>
+    <VersionPrefix>1.4.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->


### PR DESCRIPTION
Closes microsoft/kiota-abstractions-dotnet#274 